### PR TITLE
Fix __contains filter

### DIFF
--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -406,7 +406,8 @@ class SearchNode(tree.Node):
         field = parts[0]
 
         if len(parts) == 1 or parts[-1] not in VALID_FILTERS:
-            filter_type = 'contains'
+            # FIXME: we should raise an error for unknown filters to avoid confusion:
+            filter_type = 'matches'
         else:
             filter_type = parts.pop()
 

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -405,11 +405,13 @@ class SearchNode(tree.Node):
         parts = expression.split(FILTER_SEPARATOR)
         field = parts[0]
 
-        if len(parts) == 1 or parts[-1] not in VALID_FILTERS:
-            # FIXME: we should raise an error for unknown filters to avoid confusion:
+        if len(parts) == 1:
             filter_type = 'matches'
         else:
             filter_type = parts.pop()
+
+        if filter_type not in VALID_FILTERS:
+            raise ValueError('Expression %s has an unknown filter type %s' % (expression, filter_type))
 
         return (field, filter_type)
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -780,7 +780,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
-            'contains': u'%s',
+            'contains': u'*%s*',
             'startswith': u'%s*',
             'exact': u'%s',
             'gt': u'{%s TO *}',

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -780,6 +780,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
+            'matches': u'%s',
             'contains': u'*%s*',
             'startswith': u'%s*',
             'exact': u'%s',
@@ -792,7 +793,7 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         if value.post_process is False:
             query_frag = prepared_value
         else:
-            if filter_type in ['contains', 'startswith']:
+            if filter_type in ['matches', 'contains', 'startswith']:
                 if value.input_type_name == 'exact':
                     query_frag = prepared_value
                 else:

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -549,6 +549,7 @@ class SolrSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
+            'matches': u'%s',
             'contains': u'*%s*',
             'startswith': u'%s*',
             'exact': u'%s',
@@ -561,7 +562,7 @@ class SolrSearchQuery(BaseSearchQuery):
         if value.post_process is False:
             query_frag = prepared_value
         else:
-            if filter_type in ['contains', 'startswith']:
+            if filter_type in ['matches', 'contains', 'startswith']:
                 if value.input_type_name == 'exact':
                     query_frag = prepared_value
                 else:

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -549,7 +549,7 @@ class SolrSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
-            'contains': u'%s',
+            'contains': u'*%s*',
             'startswith': u'%s*',
             'exact': u'%s',
             'gt': u'{%s TO *}',

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -820,7 +820,7 @@ class WhooshSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
-            'contains': '%s',
+            'contains': '*%s*',
             'startswith': "%s*",
             'exact': '%s',
             'gt': "{%s to}",

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -820,6 +820,7 @@ class WhooshSearchQuery(BaseSearchQuery):
             index_fieldname = u'%s:' % connections[self._using].get_unified_index().get_index_fieldname(field)
 
         filter_types = {
+            'matches': '%s',
             'contains': '*%s*',
             'startswith': "%s*",
             'exact': '%s',
@@ -832,7 +833,7 @@ class WhooshSearchQuery(BaseSearchQuery):
         if value.post_process is False:
             query_frag = prepared_value
         else:
-            if filter_type in ['contains', 'startswith']:
+            if filter_type in ['matches', 'contains', 'startswith']:
                 if value.input_type_name == 'exact':
                     query_frag = prepared_value
                 else:

--- a/haystack/constants.py
+++ b/haystack/constants.py
@@ -15,7 +15,10 @@ DJANGO_ID = getattr(settings, 'HAYSTACK_DJANGO_ID_FIELD', 'django_id')
 DEFAULT_OPERATOR = getattr(settings, 'HAYSTACK_DEFAULT_OPERATOR', 'AND')
 
 # Valid expression extensions.
-VALID_FILTERS = set(['contains', 'exact', 'gt', 'gte', 'lt', 'lte', 'in', 'startswith', 'range'])
+# These generally follow the standard Django ORM lookup filters except for `matches`,
+# which follows the old fuzzy search engine behaviour – e.g. `foo bar` is treated as "foo AND bar" without
+# the ordering restriction imposed by `contains`:
+VALID_FILTERS = {'matches', 'contains', 'exact', 'gt', 'gte', 'lt', 'lte', 'in', 'startswith', 'range'}
 FILTER_SEPARATOR = '__'
 
 # The maximum number of items to display in a SearchQuerySet.__repr__

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_backend.py
@@ -835,7 +835,7 @@ class LiveElasticsearchSearchQuerySetTestCase(TestCase):
         # This will break horrifically if escaping isn't working.
         sqs = self.sqs.auto_query('"pants:rule"')
         self.assertTrue(isinstance(sqs, SearchQuerySet))
-        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__contains="pants:rule">')
+        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__matches="pants:rule">')
         self.assertEqual(sqs.query.build_query(), u'("pants\\:rule")')
         self.assertEqual(len(sqs), 0)
 

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -115,6 +115,10 @@ class ElasticsearchSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(title__startswith='haystack'))
         self.assertEqual(self.sq.build_query(), u'((why) AND title:(haystack*))')
 
+    def test_build_query_contains_filter(self):
+        self.sq.add_filter(SQ(content__contains='test'))
+        self.assertEqual(self.sq.build_query(), u'(*test*)')
+
     def test_clean(self):
         self.assertEqual(self.sq.clean('hello world'), 'hello world')
         self.assertEqual(self.sq.clean('hello AND world'), 'hello and world')

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -953,7 +953,7 @@ class LiveSolrSearchQuerySetTestCase(TestCase):
         # This will break horrifically if escaping isn't working.
         sqs = self.sqs.auto_query('"pants:rule"')
         self.assertTrue(isinstance(sqs, SearchQuerySet))
-        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__contains="pants:rule">')
+        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__matches="pants:rule">')
         self.assertEqual(sqs.query.build_query(), u'("pants\\:rule")')
         self.assertEqual(len(sqs), 0)
 

--- a/test_haystack/solr_tests/test_solr_query.py
+++ b/test_haystack/solr_tests/test_solr_query.py
@@ -81,6 +81,10 @@ class SolrSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(rating__range=[3, 5]))
         self.assertEqual(self.sq.build_query(), u'((why) AND pub_date:([* TO "2009-02-10 01:59:00"]) AND author:({"daniel" TO *}) AND created:({* TO "2009-02-12 12:13:00"}) AND title:(["B" TO *]) AND id:("1" OR "2" OR "3") AND rating:(["3" TO "5"]))')
 
+    def test_build_query_contains_filter(self):
+        self.sq.add_filter(SQ(content__contains='test'))
+        self.assertEqual(self.sq.build_query(), u'(*test*)')
+
     def test_build_complex_altparser_query(self):
         self.sq.add_filter(SQ(content=AltParser('dismax', "Don't panic", qf='text')))
         self.sq.add_filter(SQ(pub_date__lte=Exact('2009-02-10 01:59:00')))

--- a/test_haystack/test_managers.py
+++ b/test_haystack/test_managers.py
@@ -168,12 +168,12 @@ class ManagerTestCase(TestCase):
     def test_auto_query(self):
         sqs = self.search_index.objects.auto_query('test search -stuff')
         self.assertTrue(isinstance(sqs, SearchQuerySet))
-        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__contains=test search -stuff>')
+        self.assertEqual(repr(sqs.query.query_filter), '<SQ: AND content__matches=test search -stuff>')
 
         # With keyword argument
         sqs = self.search_index.objects.auto_query('test search -stuff', fieldname='title')
         self.assertTrue(isinstance(sqs, SearchQuerySet))
-        self.assertEqual(repr(sqs.query.query_filter), "<SQ: AND title__contains=test search -stuff>")
+        self.assertEqual(repr(sqs.query.query_filter), "<SQ: AND title__matches=test search -stuff>")
 
     def test_autocomplete(self):
         # Not implemented

--- a/test_haystack/test_query.py
+++ b/test_haystack/test_query.py
@@ -45,8 +45,9 @@ class SQTestCase(TestCase):
         self.assertEqual(sq.split_expression('foo__startswith'), ('foo', 'startswith'))
         self.assertEqual(sq.split_expression('foo__range'), ('foo', 'range'))
 
-        # Unrecognized filter. Fall back to exact.
-        self.assertEqual(sq.split_expression('foo__moof'), ('foo', 'matches'))
+    def test_invalid_filter_type(self):
+        sq = SQ(foo='bar')
+        self.assertRaises(ValueError, sq.split_expression, 'foo__moof')
 
     def test_repr(self):
         self.assertEqual(repr(SQ(foo='bar')), '<SQ: AND foo__matches=bar>')

--- a/test_haystack/whoosh_tests/test_whoosh_query.py
+++ b/test_haystack/whoosh_tests/test_whoosh_query.py
@@ -98,6 +98,10 @@ class WhooshSearchQueryTestCase(WhooshTestCase):
         self.sq.add_filter(SQ(title__startswith='haystack'))
         self.assertEqual(self.sq.build_query(), u'((why) AND title:(haystack*))')
 
+    def test_build_query_contains_filter(self):
+        self.sq.add_filter(SQ(content__contains='test'))
+        self.assertEqual(self.sq.build_query(), u'(*test*)')
+
     def test_clean(self):
         self.assertEqual(self.sq.clean('hello world'), 'hello world')
         self.assertEqual(self.sq.clean('hello AND world'), 'hello and world')


### PR DESCRIPTION
WIP: this needs a decision about how to handle backwards compatibility because the current default is that the "contains" operator is used for `field=` and `field__contains=`. If we change it, a large number of tests and presumably real applications will break like this:

https://travis-ci.org/acdha/django-haystack/jobs/86398500#L1373-L1382

This would probably make the most sense to follow the Django ORM behaviour and have `field=` remain an exact match.

Closes #1041
Closes #1060
Closes #1061
Closes #1227
